### PR TITLE
Enhance UkuleleFretboard: map note names to string/fret positions

### DIFF
--- a/app/routes/ukulele_chords.tsx
+++ b/app/routes/ukulele_chords.tsx
@@ -10,20 +10,20 @@ export function meta({ }: Route.MetaArgs) {
 }
 
 const chords = [
-  { name: "C", markers: [[4, 0], [3, 0], [2, 0], [1, 3]] },
-  { name: "Dm", markers: [[4, 2], [3, 2], [2, 1], [1, 0]] },
-  { name: "Em", markers: [[4, 0], [3, 4], [2, 3], [1, 2]] },
-  { name: "F", markers: [[4, 2], [3, 0], [2, 1], [1, 0]] },
-  { name: "G", markers: [[4, 0], [3, 2], [2, 3], [1, 2]] },
-  { name: "Am", markers: [[4, 2], [3, 0], [2, 0], [1, 0]] },
-  { name: "Bdim", markers: [[4, 4], [3, 2], [2, 2], [1, 2]] },
+  { name: "C", markers: ["G4", "C4", "E4", "C5"]},
+  { name: "Dm", markers: ["A4", "D4", "F4", "A4"] },
+  { name: "Em", markers: ["G4", "E4", "G4", "B4"] },
+  { name: "F", markers: ["A4", "C4", "F4", "A4"] },
+  { name: "G", markers: ["G4", "D4", "G4", "B4"] },
+  { name: "Am", markers: ["A4", "C4", "E4", "A4"] },
+  { name: "Bdim", markers: ["B4", "D4", "F#4", "B4"] },
 ];
 
 export default function UkuleleChordsHomePage() {
   return (
     <div className="ukulele-chords-list">
       {chords.map(({ name, markers }) => (
-        <div className="ukulele-chord">
+        <div className="ukulele-chord" key={name}>
          <span className="ukulele-fret-number">{name}</span>
           <UkuleleFretboard markers={markers} />
         </div>

--- a/app/ukulele-fretboard/ukulele-fretboard.tsx
+++ b/app/ukulele-fretboard/ukulele-fretboard.tsx
@@ -1,9 +1,39 @@
 import React from 'react';
 import './ukulele.css';
 
+// Notas por cuerda desde el traste 0 hasta el 4
+const fretboardNotes = {
+  4: ["G4", "G#4", "A4", "A#4", "B4"],
+  3: ["C4", "C#4", "D4", "D#4", "E4"],
+  2: ["E4", "F4", "F#4", "G4", "G#4"],
+  1: ["A4", "A#4", "B4", "C5", "C#5"]
+};
+
+// Devuelve [cuerda, traste] para una nota (si existe)
+function findNotePosition(note) {
+  for (let string in fretboardNotes) {
+    const fret = fretboardNotes[string].indexOf(note);
+    if (fret !== -1) {
+      return [parseInt(string), fret];
+    }
+  }
+  return null;
+}
+
 export default function UkuleleFretboard({ markers = [] }) {
   const fretCount = 5;
   const stringCount = 4;
+
+  const marks = markers
+  .map((note, i) => {
+    const string = 4 - i;
+    const fret = fretboardNotes[string]?.indexOf(note);
+    if (fret > 0) {
+      return [string, fret];
+    }
+    return null;
+  })
+  .filter(Boolean);
 
   return (
     <div className="ukulele">
@@ -19,19 +49,15 @@ export default function UkuleleFretboard({ markers = [] }) {
         ))}
 
         {Array.from({ length: fretCount }, (_, i) => (
-          <>
-            <div
-              className="fret-line"
-              style={{ top: `${(i) * (100 / fretCount)}%` }}
-            />
-          </>
+          <div
+            key={i}
+            className="fret-line"
+            style={{ top: `${i * (100 / fretCount)}%` }}
+          />
         ))}
 
-        {markers.map(([humanString, fret], i) => {
-          if (fret === 0) return null; // no mostrar si es al aire
-
-          const string = 5 - humanString; // invertir para que 1 sea aguda y 4 grave
-          const fretCount = 5;
+        {marks.map(([humanString, fret], i) => {
+          const string = 5 - humanString;
 
           return (
             <div
@@ -39,12 +65,11 @@ export default function UkuleleFretboard({ markers = [] }) {
               className="marker"
               style={{
                 left: `${20 * string}%`,
-                top: `${(fret - 0.5) * (100 / fretCount)}%`, // traste 1 = primer bloque
+                top: `${(fret - 0.5) * (100 / fretCount)}%`,
               }}
             />
           );
         })}
-
       </div>
     </div>
   );

--- a/stories/ukuleleFretboard.stories.jsx
+++ b/stories/ukuleleFretboard.stories.jsx
@@ -4,7 +4,14 @@ import UkuleleFretboard from "../app/ukulele-fretboard/ukulele-fretboard";
 
 export default {
   title: "Components/UkuleleFretboard",
-  component: UkuleleFretboard
+  component: UkuleleFretboard,
+  decorators: [
+    (Story) => (
+      <div style={{ width: "150px" }}>
+        <Story />
+      </div>
+    ),
+  ]
 };
 
 const Template = (args) => <UkuleleFretboard {...args} />;
@@ -16,15 +23,15 @@ withoutMarkers.args = {
 
 export const with1MarkerCmajChord = Template.bind({});
 with1MarkerCmajChord.args = {
-  markers: [[4, 0], [3, 0], [2, 0], [1, 3]] 
+  markers: ["G4", "C4", "E4", "C5"]
 };
 
 export const with3MarkersEminChord = Template.bind({});
 with3MarkersEminChord.args = {
-  markers: [[4, 0], [3, 4], [2, 3], [1, 2]] 
+  markers: ["G4", "E4", "G4", "B4"]
 };
 
 export const with4MarkersBmajChord = Template.bind({});
 with4MarkersBmajChord.args = {
-  markers: [[4, 4], [3, 3], [2, 2], [1, 2]] 
+  markers: ["B4", "D4", "F#4", "B4"]
 };


### PR DESCRIPTION
This update allows the `UkuleleFretboard` component to accept musical note names like `"C4"` instead of manual `[string, fret]` pairs. It improves readability and simplifies chord definitions across the app and Storybook. 

~Backwards compatibility is preserved for existing numeric input.~ Just simply NO

📝 Note: I owe you tests — someday, in a distant future. 
Fow no let's keep it fun (and test-free... for now). 😎🎸
