### PR TITLE
Fix Storybook import error for OctaveRangeType from pianobase.types

### DIFF
--- a/app/pianobase/pianobase.tsx
+++ b/app/pianobase/pianobase.tsx
@@ -3,14 +3,9 @@ import * as Tone from "tone";
 import React, { useState, useEffect, useRef } from "react";
 import { Button, DropdownMenu } from "@radix-ui/themes";
 import { HamburgerMenuIcon } from "@radix-ui/react-icons";
+import type { PianoBaseProps, chordMapType, OctaveRangeType } from "./pianobase.types";
 
-type PianoBaseProps = {
-  createSynth?: () => Tone.Synth | Tone.DuoSynth;
-  chordMap?: Record<string, string[]>;
-  octaves?: 1 | 2 | 3 | 4 | 5;
-};
-
-const defaultChordMap: Record<string, string[]> = {
+const defaultChordMap: chordMapType = {
   Dmaj_4: ["D4", "A4", "F#5", "A5", "D6"],
   Emin_4: ["E4", "B4", "G5", "B5", "E6"],
   Gbmin_4: ["F#4", "C#5", "A5", "C#6", "F#6"],
@@ -22,16 +17,13 @@ const defaultChordMap: Record<string, string[]> = {
   Dmaj_5: ["D5", "A5", "F#6", "A6", "D7"],
 };
 
-const generateNotes = function (octaves = 3, startOctave = 4) {
-  const whiteNotes = ["C", "D", "E", "F", "G", "A", "B"];
-  const blackNotes = ["C#", "D#", "", "F#", "G#", "A#", "", "C#", "D#", "", "F#", "G#", "A#"];
-
+const generateNotes = function (octaves: OctaveRangeType = 3, startOctave: OctaveRangeType = 4) {
   const white = [];
   const black = [];
 
   for (let i = 0; i < octaves; i++) {
     const currentOctave = startOctave + i;
-    white.push(...whiteNotes.map(n => `${n}${currentOctave}`));
+    white.push(...["C", "D", "E", "F", "G", "A", "B"].map(n => `${n}${currentOctave}`));
     black.push(...["C#", "D#", "F#", "G#", "A#"].map(n => `${n}${currentOctave}`));
   }
 
@@ -41,7 +33,7 @@ const generateNotes = function (octaves = 3, startOctave = 4) {
   return { white, black };
 }
 
-function getBlackKeyWidth(octaves: number): string {
+function getBlackKeyWidth(octaves: OctaveRangeType): string {
   if (octaves <= 1) return "7%";
   if (octaves === 2) return "4%";
   if (octaves === 3) return "3%";
@@ -49,7 +41,7 @@ function getBlackKeyWidth(octaves: number): string {
   return "1.4%";
 }
 
-export function PianoBase({
+export default function PianoBase({
   createSynth,
   chordMap = defaultChordMap,
   octaves = 3

--- a/app/pianobase/pianobase.types.ts
+++ b/app/pianobase/pianobase.types.ts
@@ -1,0 +1,9 @@
+export type OctaveRangeType = 1 | 2 | 3 | 4 | 5;
+export type chordMapType = Record<string, string[]>;
+
+export type PianoBaseProps = {
+  createSynth?: () => Tone.Synth | Tone.DuoSynth;
+  chordMap?: chordMapType;
+  octaves?: OctaveRangeType;
+};
+

--- a/app/pianos/piano1.tsx
+++ b/app/pianos/piano1.tsx
@@ -1,11 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption1() {
+export function PianoOption1({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase
-        octaves={1}
+        octaves={octaves}
+        chordMap={chordMap}
         createSynth={() => {
           const synth = new Tone.DuoSynth({
             vibratoAmount: 0.1,

--- a/app/pianos/piano2.tsx
+++ b/app/pianos/piano2.tsx
@@ -1,11 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption2() {
+export function PianoOption2({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase
-        octaves={1}
+        chordMap={chordMap}
+        octaves={octaves}
         createSynth={() => {
           const synth = new Tone.DuoSynth({
             vibratoAmount: 0.7,

--- a/app/pianos/piano3.tsx
+++ b/app/pianos/piano3.tsx
@@ -1,11 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption3() {
+export function PianoOption3({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase
-        octaves={1}
+        chordMap={chordMap}
+        octaves={octaves}
         createSynth={() => {
           const synth = new Tone.DuoSynth({
             vibratoAmount: 0.7,

--- a/app/pianos/piano5.tsx
+++ b/app/pianos/piano5.tsx
@@ -1,11 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption5() {
+export function PianoOption5({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase
-        octaves={1}
+        chordMap={chordMap}
+        octaves={octaves}
         createSynth={() => {
           const synth = new Tone.FMSynth({
             harmonicity: 8,

--- a/app/pianos/piano6.tsx
+++ b/app/pianos/piano6.tsx
@@ -1,10 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption6() {
+export function PianoOption6({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase 
+        chordMap={chordMap}
+        octaves={octaves}
         createSynth={() => {
           // Synth melódico tipo campanilla de madera
           const synth = new Tone.Synth({

--- a/app/pianos/piano7.tsx
+++ b/app/pianos/piano7.tsx
@@ -1,10 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption7() {
+export function PianoOption7({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase
+        chordMap={chordMap}
+        octaves={octaves}
         createSynth={() => {
           // PolySynth para varias voces
           const synth = new Tone.PolySynth(Tone.Synth, {

--- a/app/pianos/piano8.tsx
+++ b/app/pianos/piano8.tsx
@@ -1,10 +1,13 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps } from "../pianobase/pianobase.types";
 
-export function PianoOption8() {
+export function PianoOption8({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase
+        chordMap={chordMap}
+        octaves={octaves}
         octaves={1}
         createSynth={() => {
           //  metálico pulsante

--- a/app/pianos/piano_ukulele.tsx
+++ b/app/pianos/piano_ukulele.tsx
@@ -1,7 +1,8 @@
 import * as Tone from "tone";
-import { PianoBase } from "../pianobase/pianobase";
+import PianoBase from "../pianobase/pianobase";
+import type { PianoBaseProps, chordMapType } from "../pianobase/pianobase.types";
 
-export function PianoUkulele() {
+export function PianoUkulele({ chordMap, octaves = 1 }: PianoBaseProps) {
   return (
     <>
       <PianoBase

--- a/stories/PianoOption2.stories.jsx
+++ b/stories/PianoOption2.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Theme } from '@radix-ui/themes';
-import {PianoOption2} from "../app/pianos/piano2";
+import { PianoOption2 } from "../app/pianos/piano2";
 
 export default {
   title: "Components/PianoOption2",
@@ -19,4 +19,5 @@ const Template = (args) => <PianoOption2 {...args} />;
 export const SinAcordes = Template.bind({});
 SinAcordes.args = {
   chordMap: {}, // sin acordes
+  octaves: 2
 };

--- a/stories/pianobase.stories.jsx
+++ b/stories/pianobase.stories.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Theme } from '@radix-ui/themes';
-import {PianoBase} from "../app/pianobase/PianoBase";
+import PianoBase from "../app/pianobase/PianoBase";
 import '@radix-ui/themes/styles.css';
 
 export default {
@@ -38,4 +38,26 @@ with3Chords.args = {
     Dmin: ["D4", "F4", "A4"],
     G7: ["G3", "B3", "D4", "F4"],
   },
+};
+
+export const with1Octave = Template.bind({});
+with1Octave.args = {
+  octaves: 1,
+};
+
+export const with2Octave = Template.bind({});
+with2Octave.args = {
+  octaves: 2,
+};
+export const with3Octave = Template.bind({});
+with3Octave.args = {
+  octaves: 3,
+};
+export const with4Octave = Template.bind({});
+with4Octave.args = {
+  octaves: 4,
+};
+export const with5Octave = Template.bind({});
+with5Octave.args = {
+  octaves: 5,
 };


### PR DESCRIPTION

- Added explicit TypeScript definitions for the Piano component props.
- Refactored Storybook stories to accept all parameters via `args`.