### PR TITLE
Add PianoObserver and MiniDashboard with recent notes display

### DIFF
--- a/app/Observer/Observer.ts
+++ b/app/Observer/Observer.ts
@@ -1,0 +1,22 @@
+type PianoEvent = 
+  | { type: "notePlayed", note: string }
+  | { type: "chordPlayed", chord: string[] }
+  | { type: "sequenceEnded" };
+
+type Listener = (event: PianoEvent) => void;
+
+export class PianoObservable {
+  private listeners: Listener[] = [];
+
+  subscribe(listener: Listener) {
+    this.listeners.push(listener);
+    // Devuelve función para desuscribirse
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener);
+    };
+  }
+
+  notify(event: PianoEvent) {
+    this.listeners.forEach(listener => listener(event));
+  }
+}

--- a/app/PianoBase/PianoBase.tsx
+++ b/app/PianoBase/PianoBase.tsx
@@ -1,6 +1,5 @@
 import * as Tone from "tone";
 import React, { useState, useEffect, useRef } from "react";
-import { HamburgerMenuIcon } from "@radix-ui/react-icons";
 import {
   DEFAULT_CHORD_MAP,
   generateNotes,
@@ -18,7 +17,7 @@ import type {
   tNoteWithOctave, tNoteWOCtaveQuality,
   tSequenceToPlayProps, tTime, tNoteName
 } from "./PianoBase.types";
-
+import { PianoObservable } from "../Observer/Observer";
 import './PianoBase.css';
 
 export interface PianoBaseProps {
@@ -28,6 +27,7 @@ export interface PianoBaseProps {
   octaves?: tOctaveRange;
   highlightOnThePiano?: tChord;
   sequenceToPlay?: tSequenceToPlayProps;
+  pianoObservable?: PianoObservable;
 }
 
 export default function PianoBase({
@@ -36,7 +36,8 @@ export default function PianoBase({
   octave = 4,
   octaves = 3,
   highlightOnThePiano,
-  sequenceToPlay
+  sequenceToPlay,
+  pianoObservable,
 }: PianoBaseProps) {
   const synthRef = useRef<SupportedSynthType | null>(null);
   const [activeNotes, setActiveNotes] = useState<tChord>([]);
@@ -123,6 +124,7 @@ export default function PianoBase({
   const handlePianoKeyClick = (note: tNoteWithOctave) => {
     setActiveNotes([note]);
     playNote(note, synthRef.current);
+    pianoObservable?.notify({ type: "notePlayed", note });
     setTimeout(() => setActiveNotes([]), 180);
   };
 

--- a/app/pianos/PianoMiniDashboard/PianoMiniDashboard.tsx
+++ b/app/pianos/PianoMiniDashboard/PianoMiniDashboard.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+import PianoBase from "../../PianoBase/PianoBase";
+import { PianoObservable } from "../../Observer/Observer";
+
+// Instancia única, puedes mover esto a un contexto si lo necesitas global
+const pianoObservable = new PianoObservable();
+
+export default function PianoMiniDashboard() {
+  // Estado para guardar las últimas notas presionadas
+  const [recentNotes, setRecentNotes] = useState<string[]>([]);
+
+  useEffect(() => {
+    // Suscribirse a eventos de PianoObservable
+    const unsubscribe = pianoObservable.subscribe(event => {
+      if (event.type === "notePlayed") {
+        setRecentNotes(prev => {
+          // Mantén solo las últimas 5 notas (ajusta el número como quieras)
+          const newNotes = [event.note, ...prev];
+          return newNotes.slice(0, 5);
+        });
+      }
+    });
+    // Limpia la suscripción al desmontar el componente
+    return unsubscribe;
+  }, []);
+
+  return (
+    <div className="piano-mini-dashboard">
+      <h2>Piano Mini Dashboard</h2>
+
+      <div>
+        <h3>Últimas teclas presionadas:</h3>
+        {recentNotes.join(", ") || "No hay teclas presionadas aún."}
+      </div>
+
+      <PianoBase pianoObservable={pianoObservable} />
+    </div>
+  );
+}

--- a/stories/PianoMiniDashboard.stories.tsx
+++ b/stories/PianoMiniDashboard.stories.tsx
@@ -10,5 +10,3 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const defaultOption: Story = {};
-
-export const withEmptyChordMap: Story = {};

--- a/stories/PianoMiniDashboard.stories.tsx
+++ b/stories/PianoMiniDashboard.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PianoMiniDashboard from '../app/pianos/PianoMiniDashboard/PianoMiniDashboard';
+
+const meta = {
+  title: "Experiments/Piano Mini Dashboard",
+  component: PianoMiniDashboard,
+} satisfies Meta<typeof PianoMiniDashboard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const defaultOption: Story = {};
+
+export const withEmptyChordMap: Story = {};


### PR DESCRIPTION
Se agrega un observable para eventos del piano y un MiniDashboard que muestra las últimas notas presionadas en tiempo real.

<img width="801" alt="image" src="https://github.com/user-attachments/assets/ed214f14-ce74-49a3-a7e6-50a0ca5e3b7a" />
